### PR TITLE
Add openapi2apigee package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
     apt-get install -y git-core python php-cli php-curl nodejs curl && \
     node -v && \
     npm -v && \
-    npm install apigeetool -g
+    npm install apigeetool -g \
+    npm install openapi2apigee -g
 
 VOLUME /code
 WORKDIR /code


### PR DESCRIPTION
Helps to build apigee packages from swagger/openapi specs.